### PR TITLE
Fix/traefik-healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ This file documents the changes made to the original project from the [tutorial 
 
 ## [Unreleased]
 
+### Security
+
+-   **Traefik Hardening**: Switched from Docker/Podman socket to a file-based provider (`./traefik/dynamic_conf.yml`) to reduce attack surface and enhance security by preventing direct access to the container daemon.
+
+### Added
+
+-   **Security Policy (`SECURITY.md`)**: Added a formal security policy with instructions for reporting vulnerabilities.
+-   **Traffic Security Analysis (`docs/traffic-security-analysis.md`)**: New documentation detailing the data flow and security measures at each layer of the stack.
+
+### Changed
+
+-   **Pinned Image Versions**: Pinned the `n8n` image to the `stable` tag and `traefik` to `v3.5` for more stable and predictable deployments.
+-   **Synchronized Compose Files**: Updated `podman-compose.yml` to align with the latest improvements in `docker-compose.yml`.
+-   **Podman Documentation**: Overhauled `docs/podman-setup.md` to reflect the new file-based configuration for Traefik.
+
+## [1.0.0] - 2025-08-13
+
 ### Added
 
 -   **Podman Support**: Added `podman-compose.yml` to enable running the stack with Podman.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - "--providers.file.directory=/etc/traefik/dynamic"
       - "--providers.file.watch=true"
       # - "--serversTransport.insecureSkipVerify=true" # Allow self-signed certificates for target hosts - https://doc.traefik.io/traefik/routing/overview/#insecureskipverify
+      - "--entrypoints.traefik.address=:8080"
       - "--entrypoints.n8n_ui.address=:8082"
       - "--entrypoints.n8n_webhook.address=:8083"
     ports:

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -46,6 +46,7 @@ services:
       - "--providers.file.directory=/etc/traefik/dynamic"
       - "--providers.file.watch=true"
       # - "--serversTransport.insecureSkipVerify=true" # Allow self-signed certificates for target hosts - https://doc.traefik.io/traefik/routing/overview/#insecureskipverify
+      - "--entrypoints.traefik.address=:8080"
       - "--entrypoints.n8n_ui.address=:8082"
       - "--entrypoints.n8n_webhook.address=:8083"
     ports:


### PR DESCRIPTION
The traefik healthcheck was failing because the /ping endpoint was not available. This change adds the 'traefik' entrypoint on port 8080 to make the healthcheck pass. The insecure API is configured to use this entrypoint by default.